### PR TITLE
Standalone mode and smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,35 +16,18 @@ This charm supports running Pig in two execution modes:
 
 ## Usage
 
-This charm leverages our pluggable Hadoop model with the `hadoop-plugin`
-interface. This means that you will need to deploy a base Apache Hadoop cluster
-to run Pig. The suggested deployment method is to use the
-[apache-analytics-pig](https://jujucharms.com/apache-analytics-pig/)
-bundle. This will deploy the Apache Hadoop platform with a single Apache Pig
-unit that communicates with the cluster by relating to the
-`apache-hadoop-plugin` subordinate charm:
+This charm is intended to be deployed via the
+[apache-analytics-pig](https://jujucharms.com/apache-analytics-pig) bundle:
 
-    juju deploy apache-analytics-pig
+    juju quickstart apache-analytics-pig
 
-Alternatively, you may manually deploy the recommended environment as follows:
-
-    juju deploy apache-hadoop-namenode namenode
-    juju deploy apache-hadoop-resourcemanager resourcemgr
-    juju deploy apache-hadoop-slave slave
-    juju deploy apache-hadoop-plugin plugin
-    juju deploy apache-pig pig
-
-    juju add-relation resourcemgr namenode
-    juju add-relation namenode slave
-    juju add-relation resourcemgr slave
-    juju add-relation plugin namenode
-    juju add-relation plugin resourcemgr
-    juju add-relation pig plugin
+This will deploy the Apache Hadoop platform with Apache Pig available to
+execute Pig Latin jobs on your data. Once deployment is complete, you can run
+Pig in a variety of modes:
 
 ### Local Mode
 
-Once deployment is complete, run Pig in local mode on the Pig unit with the
-following:
+Run Pig in local mode on the Pig unit with the following:
 
     juju ssh pig/0
     pig -x local
@@ -58,29 +41,33 @@ and run pig as follows:
     pig
 
 
-## Testing the deployment
+## Status and Smoke Test
 
-### Smoke test Local Mode
+The services provide extended status reporting to indicate when they are ready:
 
-SSH to the Pig unit and run pig as follows:
+    juju status --format=tabular
 
-    juju ssh pig/0
-    pig -x local
-    quit
-    exit
+This is particularly useful when combined with `watch` to track the on-going
+progress of the deployment:
 
-### Smoke test MapReduce Mode
+    watch -n 0.5 juju status --format=tabular
 
-SSH to the Pig unit and test in MapReduce mode as follows:
+The message for each unit will provide information about that unit's state.
+Once they all indicate that they are ready, you can perform a "smoke test"
+to verify that Spark is working as expected using the built-in `smoke-test`
+action:
 
-    juju ssh pig/0
-    hdfs dfs -mkdir -p /user/ubuntu
-    hdfs dfs -copyFromLocal /etc/passwd /user/ubuntu/passwd
-    echo "A = load '/user/ubuntu/passwd' using PigStorage(':');" > /tmp/test.pig
-    echo "B = foreach A generate \$0 as id; store B into '/tmp/pig.out';" >> /tmp/test.pig
-    pig -l /tmp/test.log /tmp/test.pig
-    hdfs dfs -cat /tmp/pig.out/part-m-00000
-    exit
+    juju action do pig/0 smoke-test
+
+After a few seconds or so, you can check the results of the smoke test:
+
+    juju action status
+
+You will see `status: completed` if the smoke test was successful, or
+`status: failed` if it was not.  You can get more information on why it failed
+via:
+
+    juju action fetch <action-id>
 
 
 ## Contact Information

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,2 @@
+smoke-test:
+    description: Verify that Pig is working.

--- a/actions/smoke-test
+++ b/actions/smoke-test
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+
+from path import Path
+
+from charmhelpers.core import hookenv
+from jujubigdata.utils import run_as
+from charms.reactive import is_state
+
+
+def fail(msg, output):
+    hookenv.action_set({'output': output})
+    hookenv.action_fail(msg)
+    sys.exit()
+
+if not (is_state('pig.configured.local') or is_state('pig.configured.yarn')):
+    fail('Pig service not yet ready')
+
+
+def _run_pig_script(script, local=False):
+    Path('/tmp/test.pig').write_text(script)
+    args = ['-l', '/tmp/test.pig.log', '/tmp/test.pig']
+    if local:
+        args = ['-x', 'local'] + args
+    try:
+        run_as('ubuntu', 'pig', *args)
+    except subprocess.CalledProcessError as e:
+        fail('Pig command failed', e.output)
+
+
+if is_state('pig.configured.local'):
+    run_as('ubuntu', 'rm', '-R', '-f', '/tmp/test.pig.out')
+    script = ("A = load '/etc/passwd' using PigStorage(':'); "
+              "B = foreach A generate $0 as id; store B into '/tmp/test.pig.out';")
+    _run_pig_script(script, local=True)
+    output = run_as('ubuntu',
+                    'cat', '/tmp/test.pig.out/part-m-00000',
+                    capture_output=True)
+
+elif is_state('pig.configured.yarn'):
+    run_as('ubuntu', 'hdfs', 'dfs', '-rm', '-R', '-f', '/tmp/test.pig.out')
+    run_as('ubuntu', 'hdfs', 'dfs', '-copyFromLocal', '/etc/passwd',
+           '/user/ubuntu/test.pig.passwd')
+    script = ("A = load '/user/ubuntu/test.pig.passwd' using PigStorage(':'); "
+              "B = foreach A generate $0 as id; store B into '/tmp/test.pig.out';")
+    _run_pig_script(script, local=False)
+    output = run_as('ubuntu',
+                    'hdfs', 'dfs', '-cat', '/tmp/test.pig.out/part-m-00000',
+                    capture_output=True)
+
+if 'ubuntu' not in output:
+    fail('Unable to analyze passwd file with Pig', output)

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,4 +1,4 @@
-repo: git@github.com:juju-solutions/layer-apache-git.git
+repo: git@github.com:juju-solutions/layer-apache-pig.git
 includes: ['layer:hadoop-client']
 options:
   hadoop-client:

--- a/layer.yaml
+++ b/layer.yaml
@@ -2,16 +2,9 @@ repo: git@github.com:juju-solutions/layer-apache-git.git
 includes: ['layer:hadoop-client']
 options:
   hadoop-client:
-    groups:
-      - 'hadoop'
-      - 'mapred'
-    users:
-      pig:
-        groups: ['hadoop', 'mapred']
     dirs:
       pig:
         path: '/usr/lib/pig'
-        owner: 'pig'
-        group: 'hadoop'
       pig_conf:
         path: '/etc/pig/conf'
+    silent: True

--- a/lib/charms/layer/apache_pig.py
+++ b/lib/charms/layer/apache_pig.py
@@ -1,27 +1,63 @@
 import jujuresources
+
+from charmhelpers.core import unitdata
 from jujubigdata import utils
+from path import Path
+from subprocess import check_output
+
+
+def install_java():
+    """Install java just like we do for Hadoop Base.
+
+    This is the same method used to install java in HadoopBase:
+    https://github.com/juju-solutions/jujubigdata/blob/master/jujubigdata/handlers.py#L134
+
+    This allows us to run Pig in local mode (which requires Java) without
+    any Hadoop. If Hadoop comes along later, we'll already have java installed
+    in a way that is compatible with the plugin.
+
+    NOTE: this will go away if/when we support the java interface.
+    """
+    env = utils.read_etc_env()
+    java_installer = Path(jujuresources.resource_path('java-installer'))
+    java_installer.chmod(0o755)
+    output = check_output([java_installer], env=env).decode('utf8')
+    lines = output.strip().splitlines()
+    if len(lines) != 2:
+        raise ValueError('Unexpected output from java-installer: %s' % output)
+    java_home, java_version = lines
+    if '_' in java_version:
+        java_major, java_release = java_version.split("_")
+    else:
+        java_major, java_release = java_version, ''
+    unitdata.kv().set('java.home', java_home)
+    unitdata.kv().set('java.version', java_major)
+    unitdata.kv().set('java.version.release', java_release)
 
 
 class Pig(object):
     def __init__(self, dist_config):
         self.dist_config = dist_config
         self.resources = {
+            'java-installer': 'java-installer',
             'pig': 'pig-noarch',
         }
         self.verify_resources = utils.verify_resources(*self.resources.values())
 
     def install(self, force=False):
-        self.dist_config.add_users()
+        """Add dirs from dist.yaml and install Pig and java."""
         self.dist_config.add_dirs()
         jujuresources.install(self.resources['pig'],
                               destination=self.dist_config.path('pig'),
                               skip_top_level=True)
+        install_java()
 
-    def setup_pig(self):
-        '''
-        copy the default configuration files to pig_conf property
-        defined in dist.yaml
-        '''
+    def initial_config(self):
+        """Do one-time Pig configuration.
+
+        Copy the default configuration files to the pig_conf dir from dist.yaml
+        and adjust system environment.
+        """
         default_conf = self.dist_config.path('pig') / 'conf'
         pig_conf = self.dist_config.path('pig_conf')
         pig_conf.rmtree_p()
@@ -35,10 +71,16 @@ class Pig(object):
         with utils.environment_edit_in_place('/etc/environment') as env:
             if pig_bin not in env['PATH']:
                 env['PATH'] = ':'.join([env['PATH'], pig_bin])
-            env['PIG_CLASSPATH'] = env['HADOOP_CONF_DIR']
             env['PIG_CONF_DIR'] = self.dist_config.path('pig_conf')
             env['PIG_HOME'] = self.dist_config.path('pig')
+            env['JAVA_HOME'] = Path(unitdata.kv().get('java.home'))
 
-    def cleanup(self):
-        self.dist_config.remove_users()
-        self.dist_config.remove_dirs()
+    def configure_local(self):
+        """In local mode, configure Pig with PIG_HOME as the classpath."""
+        with utils.environment_edit_in_place('/etc/environment') as env:
+            env['PIG_CLASSPATH'] = env['PIG_HOME']
+
+    def configure_yarn(self):
+        """In mapred mode, configure Pig with HADDOP_CONF as the classpath."""
+        with utils.environment_edit_in_place('/etc/environment') as env:
+            env['PIG_CLASSPATH'] = env['HADOOP_CONF_DIR']

--- a/resources.yaml
+++ b/resources.yaml
@@ -1,5 +1,13 @@
 options:
   output_dir: /home/ubuntu/resources
+resources:
+  java-installer:
+    # This is the same installer used by hadoop-base. We include it here so
+    # pig can be run in local mode (which requires java) without Hadoop.
+    # NOTE: this goes away if/when we support the java interface.
+    url: https://s3.amazonaws.com/jujubigdata/common/noarch/java-installer-a4d52ba0.sh
+    hash: a4d52ba0eac9dc949baf28ac5235402bdb2b5bd92f239d75b6959ace8a25da6c
+    hash_type: sha256
 optional_resources:
   pig-noarch:
     url: https://s3.amazonaws.com/jujubigdata/apache/noarch/pig-0.15.0-c52112ca.tgz


### PR DESCRIPTION
Pig can be used in standalone mode as a piglatin interpreter, so enable that by installing java (same used by HadoopBase) and automatically configuring pig for standalone or mapreduce mode based on the availability of the hadoop plugin.

This PR also:
- removes unneeded users/groups since Pig doesn't have a service that needs to run as a special user
- adds smoke tests to exercise both standalone and mapreduce modes
- has a bit of readme cleanup
